### PR TITLE
Add feature to download dummy tracker based on subject split

### DIFF
--- a/searchapp/static/student_view.js
+++ b/searchapp/static/student_view.js
@@ -295,7 +295,52 @@ function upload_click(e) {
 			}
 
 		});
-	}
+  }
+
+  function base64ToArrayBuffer(base64) {
+    let binaryString = window.atob(base64.replace(/\s/g, ''));
+    let binaryLen = binaryString.length;
+    let bytes = new Uint8Array(binaryLen);
+    for (let i = 0; i < binaryLen; i++) {
+       let ascii = binaryString.charCodeAt(i);
+       bytes[i] = ascii;
+    }
+    return bytes;
+ }
+
+  function saveByteArray(reportName, byte, type) {
+	let blob = new Blob([byte], {type: type});
+	console.log(reportName);
+    saveAs(blob, reportName);
+  };
+  
+  function download_tracker(e) {
+    let subject = $("#paper-subject").dropdown('get value');
+    let splits = $('#paper-subject-splits').dropdown('get values');
+    if (splits.length != 1) {
+      new PNotify({
+        title: 'Error',
+        text: 'We currently support only one subject split at a time for dummy tracker download',
+        type: 'error'
+      });
+      return;
+    }
+		let formData = {
+			"subject_name": subject,
+			"split_name": splits[0],
+		};
+		$.ajax({
+      url: BASE_DIR + "/get_dummy_tracker",
+      method : "get",
+			data: formData,
+			headers: { "X-CSRFToken": csrftoken, crossOrigin: false},
+			success: function(response) {
+        console.log(response);
+        let sampleArr = base64ToArrayBuffer(response);
+        saveByteArray("dummy_tracker.xlsx", sampleArr, 'multipart/form-data');
+      }
+    });
+  }
 
 	function display_split_table(e)
 	{
@@ -444,7 +489,8 @@ function upload_click(e) {
 	$("#submit").click(submit_click);
 	$("#add-chapter-button").click(add_chapter);
 	$("#delete-chapters-button").click(delete_chapters);
-	$("#display-splits-button").click(display_split_table);
+  $("#display-splits-button").click(display_split_table);
+  $("#download-tracker-button").click(download_tracker);
 	$("#add-split-button").click(add_subject_split);
 	
 	

--- a/searchapp/static/student_view.js
+++ b/searchapp/static/student_view.js
@@ -23,7 +23,6 @@ $(document).ready(function(){
 	function submit_click(e) {
 		let worksheetType = $("#worksheetType").dropdown('get value');
 		if (worksheetType == 'test') {
-			console.log("submit click called");
 			let subject = $("#test-subject").dropdown('get value');
 			let chapters = $('#test-chapter').dropdown('get values');
 			let papertype = $('#test-breakup').dropdown('get value');
@@ -309,8 +308,7 @@ function upload_click(e) {
  }
 
   function saveByteArray(reportName, byte, type) {
-	let blob = new Blob([byte], {type: type});
-	console.log(reportName);
+		let blob = new Blob([byte], {type: type});
     saveAs(blob, reportName);
   };
   
@@ -335,7 +333,6 @@ function upload_click(e) {
 			data: formData,
 			headers: { "X-CSRFToken": csrftoken, crossOrigin: false},
 			success: function(response) {
-        console.log(response);
         let sampleArr = base64ToArrayBuffer(response);
         saveByteArray("dummy_tracker.xlsx", sampleArr, 'multipart/form-data');
       }
@@ -510,7 +507,6 @@ function download_token(token) {
 		request.responseType = 'blob';
 		request.onload = function() {
 			if(request.status === 200) {
-				console.log("Done");
 				let blob = new Blob([request.response], { type: 'application/pdf' });
 				let link = document.createElement('a');
 				link.href = window.URL.createObjectURL(blob);

--- a/searchapp/templates/chapter_and_split_view.html
+++ b/searchapp/templates/chapter_and_split_view.html
@@ -49,17 +49,18 @@ Edit Chapters and Subject Splits
 
 	<div class="ui grid" id="split-operations">
 			<div class="four wide column"></div>
-			<div class="six wide column">
+			<div class="five wide column">
 					<div id="paper-subject-splits" class="ui fluid multiple search selection dropdown">
 							<input name="subject-split-names" type="hidden">
 							<i class="dropdown icon"></i>
-							<div class="default text">Display Subject Splits</div>
+							<div class="default text">Show Subject Splits</div>
 							<div id="paper-subject-splits-options-parent" class="menu">
 							</div>
 					</div>
 			</div>
-			<div class="three wide column">
+			<div class="four wide column">
 					<button id="display-splits-button" class="ui button">Display</button>
+          <button id="download-tracker-button" class="ui button">Download Tracker</button>
 			</div>
 	</div>
 	<h3 class="hide-display">Delete Subject Splits</h3>

--- a/searchapp/templates/layout.html
+++ b/searchapp/templates/layout.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8"/>
@@ -12,6 +11,7 @@
     <link href="https://fonts.googleapis.com/css?family=Raleway" rel="stylesheet">
     <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.2.min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.2.14/semantic.js"></script>
+    <script src="http://cdn.jsdelivr.net/g/filesaver.js"></script>
     <script type="text/javascript" src="{% static 'student_view.js' %}"></script>
 	<script type="text/javascript" src="{% static 'pnotify.custom.min.js' %}"></script>
     <script>

--- a/searchapp/urls.py
+++ b/searchapp/urls.py
@@ -3,7 +3,6 @@ from . import views
 
 app_name='searchapp'
 urlpatterns=[
-   
    path('questions_upload',views.add_questions_view,name='questions_upload'),
    path('generated_documents', views.generated_documents_view, name='generated_documents'),
    path('download_customized_docx', views.download_customized_docx, name='download_customized_docx'),
@@ -26,5 +25,6 @@ urlpatterns=[
    path('get_customize_paper',views.get_customize_paper, name='get_customize_paper'),
    path('generate_optional_inputs',views.generate_optional_inputs,name = 'generate_optional_inputs'),
    path('',views.home, name='home'),
-   path('contact',views.contact)
+   path('contact',views.contact),
+   path('get_dummy_tracker', views.get_dummy_tracker),
 ]

--- a/searchapp/utils/utils.py
+++ b/searchapp/utils/utils.py
@@ -1,5 +1,6 @@
 import openpyxl as op
 from collections import defaultdict
+from datetime import datetime
 from random import sample
 
 def default_to_regular(d):
@@ -192,6 +193,57 @@ def convert_question_bank(question_bank_path):
             except Exception as e:
                 break
     return subject_to_chapter_to_question
+
+
+def generate_dummy_tracker(subject_name, subject_split):
+    """
+        Generate a workbook which has one tracket sheet with one dummy student
+        :param subject_name: Name of subject to which subject_split belongs to
+        :param subject_split: List of SubjectSplit objects
+        :type subject_name: str
+        :type subject_split: list
+
+        :returns: Generated workbook object
+        :rtype: openpyxl.Workbook
+    """
+    dummy_workbook = op.Workbook()
+    dummy_worksheet = dummy_workbook.active()
+
+    dummy_worksheet.title = "Tracker Record"
+    dummy_worksheet["A1"] = subject_name
+    dummy_worksheet["A2"] = "Chapter Number"
+    dummy_worksheet["A3"] = "Akshay"
+
+    thin = op.styles.Side(border_style="thin", color="000000")
+    styles_border = op.styles.Border(top=thin, left=thin, right=thin, bottom=thin)
+    styles_fillPeach = op.styles.PatternFill("solid", fgColor="fff2cc")
+    styles_fillGreen = op.styles.PatternFill("solid", fgColor="e2efda")
+
+    counter = 0
+    start_position = 1
+    end_position = 2
+    for split_object in subject_split:
+        start_position = end_position
+        end_position = start_position + split_object.total_questions
+
+        counter += 1
+        styles_currentFill = styles_fillPeach if counter % 2 else styles_fillGreen
+
+        dummy_worksheet.merge_cells("A{}:A{}".format(start_position, end_position-1))
+        dummy_worksheet["A{}".format(start_position)].border = styles_border
+        dummy_worksheet["A{}".format(start_position)].fill = styles_currentFill
+
+        for i in range(start_position, end_position):
+            dummy_worksheet["B{}".format(i)] = 0
+            dummy_worksheet["B{}".format(i)].border = styles_border
+            dummy_worksheet["B{}".format(i)].fill = styles_currentFill
+
+            dummy_worksheet["C{}".format(i)] = 0
+            dummy_worksheet["C{}".format(i)].border = styles_border
+            dummy_worksheet["C{}".format(i)].fill = styles_currentFill
+
+    return dummy_workbook
+
 
 if __name__ == "__main__":
     science_breakup = {

--- a/searchapp/utils/utils.py
+++ b/searchapp/utils/utils.py
@@ -206,41 +206,46 @@ def generate_dummy_tracker(subject_name, subject_split):
         :returns: Generated workbook object
         :rtype: openpyxl.Workbook
     """
+    char_array = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
     dummy_workbook = op.Workbook()
-    dummy_worksheet = dummy_workbook.active()
+    dummy_worksheet = dummy_workbook.active
 
     dummy_worksheet.title = "Tracker Record"
     dummy_worksheet["A1"] = subject_name
     dummy_worksheet["A2"] = "Chapter Number"
     dummy_worksheet["A3"] = "Akshay"
 
+    bold_style = op.styles.Font(size=10, bold=True)
+    dummy_worksheet["A1"].font = bold_style
+    dummy_worksheet["A2"].font = bold_style
+
     thin = op.styles.Side(border_style="thin", color="000000")
     styles_border = op.styles.Border(top=thin, left=thin, right=thin, bottom=thin)
     styles_fillPeach = op.styles.PatternFill("solid", fgColor="fff2cc")
     styles_fillGreen = op.styles.PatternFill("solid", fgColor="e2efda")
 
-    counter = 0
+    style_counter = 0
     start_position = 1
-    end_position = 2
+    end_position = 1
     for split_object in subject_split:
         start_position = end_position
         end_position = start_position + split_object.total_questions
 
-        counter += 1
-        styles_currentFill = styles_fillPeach if counter % 2 else styles_fillGreen
+        style_counter += 1
+        styles_currentFill = styles_fillPeach if style_counter % 2 else styles_fillGreen
 
-        dummy_worksheet.merge_cells("A{}:A{}".format(start_position, end_position-1))
-        dummy_worksheet["A{}".format(start_position)].border = styles_border
-        dummy_worksheet["A{}".format(start_position)].fill = styles_currentFill
+        dummy_worksheet.merge_cells("{}1:{}1".format(char_array[start_position], char_array[end_position-1]))
+        dummy_worksheet["{}1".format(char_array[start_position])].border = styles_border
+        dummy_worksheet["{}1".format(char_array[start_position])].fill = styles_currentFill
 
         for i in range(start_position, end_position):
-            dummy_worksheet["B{}".format(i)] = 0
-            dummy_worksheet["B{}".format(i)].border = styles_border
-            dummy_worksheet["B{}".format(i)].fill = styles_currentFill
+            dummy_worksheet["{}2".format(char_array[i])] = 0
+            dummy_worksheet["{}2".format(char_array[i])].border = styles_border
+            dummy_worksheet["{}2".format(char_array[i])].fill = styles_currentFill
 
-            dummy_worksheet["C{}".format(i)] = 0
-            dummy_worksheet["C{}".format(i)].border = styles_border
-            dummy_worksheet["C{}".format(i)].fill = styles_currentFill
+            dummy_worksheet["{}3".format(char_array[i])] = 0
+            dummy_worksheet["{}3".format(char_array[i])].border = styles_border
+            dummy_worksheet["{}3".format(char_array[i])].fill = styles_currentFill
 
     return dummy_workbook
 

--- a/searchapp/views.py
+++ b/searchapp/views.py
@@ -419,12 +419,13 @@ def generate_optional_inputs(request):
         allowed_chapters = [{'chapter_id': x[0], 'chapter_name': x[1]} for x in allowed_chapters]
         return JsonResponse({"message":"success","chapters":allowed_chapters,"stud_name":student_name_list,"qtype":allowed_qtype})
 
-def get_dummy_workbook(request):
+def get_dummy_tracker(request):
     if request.method == 'GET':
         split_name = request.GET['split_name']
         subject_name = request.GET['subject_name']
         subject_split_list = SubjectSplit.objects.filter(subject__subject_name__iexact=subject_name, name__iexact=split_name)
         split_list = list(subject_split_list)
-
+        import base64
         dummy_workbook = generate_dummy_tracker(subject_name, split_list)
-        response = HttpResponse(save_virtual_workbook(dummy_workbook), content_type='application/vnd.ms-excel')
+        base64_response = base64.b64encode(save_virtual_workbook(dummy_workbook)).rstrip(b'\n=')
+        return HttpResponse(base64_response, content_type='multipart/form-data')


### PR DESCRIPTION
Adds features specified in #20 

A Download button was provided alongside the Display button in `/chapter_and_split_view`
These dummy trackers do not get saved anywhere and are not generated via celery so they are downloaded immediately. 