### PR TITLE
Fix/add subject split clear fields

### DIFF
--- a/searchapp/static/student_view.js
+++ b/searchapp/static/student_view.js
@@ -300,6 +300,11 @@ function upload_click(e) {
 					type: 'success'
 				});
 				populate_chapters();
+				$('input[name=split-name]').val("");
+				$('input[name=total-questions]').val("");
+				$('input[name=questions-to-attempt]').val("");
+				$('#qweight-default').html("Select Question Weightage");
+				$('#qtype-default').html("Select Question Type");
 			}
 
 		});

--- a/searchapp/static/student_view.js
+++ b/searchapp/static/student_view.js
@@ -510,6 +510,10 @@ function upload_click(e) {
 
 	$('#question-weightage').dropdown({
 	});
+
+	//Reset Add Subject Split Dropdowns
+	$('#qtype-default').html("Select Question Type");
+	$('#qweight-default').html("Select Question Weightage");
 });
 
 function download_token(token) {

--- a/searchapp/templates/chapter_and_split_view.html
+++ b/searchapp/templates/chapter_and_split_view.html
@@ -118,4 +118,5 @@ Edit Chapters and Subject Splits
 	<button id="add-split-button" class="ui button">Add subject split</button>
 	</div>
 	<br/>
-			{% endblock %}
+	
+{% endblock %}

--- a/searchapp/templates/chapter_and_split_view.html
+++ b/searchapp/templates/chapter_and_split_view.html
@@ -88,7 +88,7 @@ Edit Chapters and Subject Splits
 	<div id="question-weightage" class="ui selection dropdown">
 		<input name="question-weightage" type="hidden">
 		<i class="dropdown icon"></i>
-		<div class="default text">Select Question Weightage</div>
+		<div class="default text" id="qweight-default">Select Question Weightage</div>
 		<div class="menu">
 			{% for element in question_weightage_choices %}
 			<div class="item" data-value="{{element.0}}">{{element.1}}</div>
@@ -100,7 +100,7 @@ Edit Chapters and Subject Splits
 	<div id="question-type" class="ui selection dropdown">
 		<input name="question-type" type="hidden">
 		<i class="dropdown icon"></i>
-		<div class="default text">Select Question Type</div>
+		<div class="default text" id="qtype-default">Select Question Type</div>
 		<div class="menu">
 			{% for element in question_type_choices %}
 			<div class="item" data-value="{{element.0}}">{{element.1}}</div>


### PR DESCRIPTION
This fixes Issue #33 
Previously, the following fields remained with their previous values after adding of new subject split:
1. Split Name
2. Question Weightage
3. Question Type
4. Total Questions
5. Questions to Attempt

This fixes this issue, so that the fields get cleared on clicking the Add Subject Split button and remain cleared when the page is reloaded.