### PR TITLE
Fix/clear fields on add subject split

### DIFF
--- a/searchapp/static/student_view.js
+++ b/searchapp/static/student_view.js
@@ -487,6 +487,8 @@ function populate_subjects(value,text, $selectedItem) {
 
   //methods for SUBJECT SPLITS.
 	$('#paper-board').dropdown('clear');
+	$('#paper-grade').dropdown('clear');
+	$('#paper-subject').dropdown('clear');
 
 	$('#paper-board').dropdown({
 		onChange: populate_grades,

--- a/searchapp/static/student_view.js
+++ b/searchapp/static/student_view.js
@@ -343,6 +343,12 @@ function populate_subjects(value,text, $selectedItem) {
 					type: 'success'
 				});
 				populate_chapters();
+				$('#question-weightage').dropdown('clear');
+				$('#question-type').dropdown('clear');
+				$('input[name="split-name"').val('');
+				$('input[name="total-questions"').val('');
+				$('input[name="questions-to-attempt"').val('');
+
 			}
 
 		});

--- a/searchapp/static/student_view.js
+++ b/searchapp/static/student_view.js
@@ -282,6 +282,7 @@ function populate_subjects(value,text, $selectedItem) {
 						type: 'success'
 					});
 					populate_chapters();
+					$('input[name="add-chapter-input"]').val('');
 				}
 			});
 		}
@@ -310,6 +311,7 @@ function populate_subjects(value,text, $selectedItem) {
 						type: 'success'
 					});
 					populate_chapters();
+					$('#paper-chapter').dropdown('clear');
 				}
 			});
 		}
@@ -489,6 +491,7 @@ function populate_subjects(value,text, $selectedItem) {
 	$('#paper-board').dropdown('clear');
 	$('#paper-grade').dropdown('clear');
 	$('#paper-subject').dropdown('clear');
+	$('#paper-chapter').dropdown('clear');
 
 	$('#paper-board').dropdown({
 		onChange: populate_grades,


### PR DESCRIPTION
This fixes #33 
- Clear fields for adding a subject split after submission
- Fixed bug where after page reload, when selecting the grade from the dropdown, the subjects dropdown is not shown
- Fixed bug where after adding a subject, when trying to select subjects to delete, dropdown shows that no results are found
- Clear fields for adding and deleting subjects after submission