### PR TITLE
Remove sections in question paper with no questions

### DIFF
--- a/searchapp/generate_doc.py
+++ b/searchapp/generate_doc.py
@@ -56,7 +56,8 @@ def convert_customized_to_doc(questions_mapping, subject):
         question_no = 0
         for qtype in qtype_to_section:
             no_of_questions = get_no_of_questions(questions_mapping[name], qtype)
-            question_no = add_questions(document, questions_mapping[name], qtype, question_no, no_of_questions)
+            if no_of_questions != 0:
+                question_no = add_questions(document, questions_mapping[name], qtype, question_no, no_of_questions)
         document.add_page_break()
     filename = "question_worksheet_" + datetime.datetime.now().__str__() + ".docx"
     filepath = os.path.join('searchapp/static/docs', filename)
@@ -70,7 +71,8 @@ def convert_to_doc(questions_mapping, subject):
     question_no = 0
     for qtype in qtype_to_section:
         no_of_questions = get_no_of_questions(questions_mapping, qtype)
-        question_no = add_questions(document, questions_mapping, qtype, question_no, no_of_questions)
+        if no_of_questions != 0:
+            question_no = add_questions(document, questions_mapping, qtype, question_no, no_of_questions)
     filename = "question_worksheet_" + datetime.datetime.now().__str__() + ".docx"
     filepath = os.path.join('searchapp/static/docs', filename)
     document.save(filepath)

--- a/searchapp/test_paper.py
+++ b/searchapp/test_paper.py
@@ -11,7 +11,7 @@ def form_test_paper_dictionary(subject, chapters, subject_breakup):
     for question_type in subject_breakup:
         final_list = []
         total_question_no = subject_breakup[question_type][0]
-        q_type, weightage = get_type_and_weightage(question_type)
+        weightage, q_type = get_type_and_weightage(question_type)
         total_list = Questions.objects.filter(question_type=q_type,
                                               question_weightage=weightage,
                                               chapter__in=Chapter.objects.filter(id__in=chapters)).values_list(


### PR DESCRIPTION
This fixes Issue #31 
- Checks if the number of questions for that section is set to 0 and removes those sections
- Fixes error in test_paper.py in function to get the weightage and question type from the question type mentioned in the breakup
