### PR TITLE
Fix customized paper generation error when not logged in

### DIFF
--- a/searchapp/static/student_view.js
+++ b/searchapp/static/student_view.js
@@ -117,6 +117,14 @@ $(document).ready(function(){
 						});
 					});
 				},
+				error: err => {
+					new PNotify({
+						title: err.responseJSON.error,
+						text: 'Click here to login',
+						type: 'error',
+					});
+					$('.brighttheme-error').click(() => window.location.href = '/login?next=/student_view')
+				}
 		});
 	}
 }
@@ -127,7 +135,7 @@ function upload_click(e) {
 		let subject = $("#customized-subject").dropdown('get value');
 		let file_data = $('#realfile').prop("files")[0];
 		let formData = new FormData();
-		formData.append("file",file_data);
+		formData.append("file", file_data);
 		formData.append('subject',subject);
 		$.ajax({
 			enctype: 'multipart/form-data',

--- a/searchapp/templates/login.html
+++ b/searchapp/templates/login.html
@@ -12,7 +12,7 @@
 <div class="form-head"><h4>MENTOR LOG-IN</h4></div>
 <br>
 <br>
-<form class="site-form" method="post" action="login">
+<form class="site-form" method="post" action="login?next={{next}}">
 {% csrf_token %}
 
 

--- a/searchapp/views.py
+++ b/searchapp/views.py
@@ -61,17 +61,20 @@ def student_view(request):
 
 
 def login_view(request):
+    next_url = request.GET.get('next') if request.GET.get('next') else ''
     if request.method == 'POST':
         form = AuthenticationForm(data=request.POST)
-        if (form.is_valid()):
+        if form.is_valid():
             user = form.get_user()
             login(request, user)
+            if next_url:
+                return redirect(next_url)
             return redirect('searchapp:mentor_view')
     else:
         if request.user.is_authenticated:
             return redirect('searchapp:mentor_view')
         form = AuthenticationForm()
-    return render(request, 'login.html', {'form': form})
+    return render(request, 'login.html', {'form': form, 'next': next_url})
 
 
 def logout_view(request):
@@ -402,12 +405,18 @@ def get_generic_paper(request):
 
 
 def get_customize_paper(request):
+    if not request.user.is_authenticated:
+        return JsonResponse({"error": "To access customised paper, you need to be logged in"}, status=401)
     if request.method == 'POST':
         subject = request.POST['subject']
         # filter returns a query set which is converted to a list and then the first element is picked up.
         subject_name = list(Subject.objects.filter(
             id=subject).values_list('subject_name', flat=True))[0]
-        chapters = map(int, request.POST.getlist('chapters[]')[0].split(','))
+        chapters = request.POST.getlist('chapters[]')[0].split(',')
+        if chapters[0]:
+            chapters = map(int, chapters)
+        else:
+            chapters = []
         sent_breakup = request.POST.getlist('breakup[]')
         sent_breakup = sent_breakup[0].split(',')
         sent_breakup = [int(x) for x in sent_breakup]
@@ -433,7 +442,6 @@ def get_customize_paper(request):
                 '5': [sent_breakup[4]] * 2,
             }
         data = convert_marker_data(file_obj, breakup)
-
         stud_data = data[0]
         allowed_chapter_nos = data[1]
         allowed_chapter_nos = list(set(allowed_chapter_nos) - set(chapters))


### PR DESCRIPTION
This fixes #34 

As of this commit, the error that occurred while generating customized
paper without logging in is fixed. The GeneratedCustomizedPaper takes a
mentor username as a filter parameter, whereas, when not logged in, it
was being fed AnonymousUser object, which was breaking the code.

This issue was fixed by checking if the user is authenticated right off
the bat, thereby not waiting for the code to reach some stage where it
could break, since anyways the user should not be allowed to generate a
customised paper without logging in. The user is then prompted to log
in, following which he is redirected to the required url from the 'next'
query parameter, for which slight alteration is also done in login_view
function

Also, this commit fixes(probably) some weird behaviour, which is,
in get_customize_paper, when chapters list is evaluated, because of the
nature of split function, an empty string is converted to a list with an
element which is an empty string as well. Running map on this list with
int function means that int('') is run, which raises an Exception. This is
fixed naively by checking for that exact condition, and thereby avoid
the exception from occurring.