### PR TITLE
Use board to choose subject split in test paper generation

### DIFF
--- a/searchapp/static/student_view.js
+++ b/searchapp/static/student_view.js
@@ -25,11 +25,10 @@ $(document).ready(function(){
 		if (worksheetType == 'test') {
 			let subject = $("#test-subject").dropdown('get value');
 			let chapters = $('#test-chapter').dropdown('get values');
-			let paperBreakup = $('#test-breakup').dropdown('get value');
 			let board = $('#test-board').dropdown('get value');
 			let formData = {
 				"subject": subject,
-				"paper-breakup": paperBreakup,
+				"board": board,
 				"chapters[]": chapters
 			}
 
@@ -231,14 +230,6 @@ function populate_subjects(value,text, $selectedItem) {
 				chapters.forEach(function(chapter){
 					$(`#${worksheetType}-chapter-options-parent`).append(`<div class="item" data-value=${chapter['chapter_id']}>${chapter['chapter_name']}</div>`);
 				})
-				if(worksheetType == 'test'){
-					$(`#${worksheetType}-breakup-options-parent`).empty();
-					$(`#${worksheetType}-breakup`).removeClass('hide-display').addClass('show-display');
-					subject_breakup.forEach(function(breakup){
-						let paperElement = `<div class="item" data-value=${breakup}>${breakup}</div>`;
-						$(`#${worksheetType}-breakup-options-parent`).append(paperElement);
-					})
-				}
 
 				if(worksheetType == 'paper')
 				{
@@ -477,11 +468,6 @@ function populate_subjects(value,text, $selectedItem) {
 	});
 
 	$('#test-chapter').dropdown({
-		onChange: function (value, text, $selectedItem) {
-		},
-	});
-
-	$('#test-breakup').dropdown({
 		onChange: function (value, text, $selectedItem) {
 		},
 	});

--- a/searchapp/views.py
+++ b/searchapp/views.py
@@ -339,13 +339,13 @@ def delete_chapters(request):
 def get_test_paper(request):
     if request.method == 'GET':
         subject = request.GET['subject']
-        paper_breakup = request.GET['paper-breakup']
+        paper_breakup = request.GET['board'] # setting board as the deciding factor for subject breakup.
         chapters = request.GET.getlist('chapters[]')
         # filter returns a query set which is converted to a list and then the first element is picked up.
         subject_name = list(Subject.objects.filter(
             id=subject).values_list('subject_name', flat=True))[0]
         subject_breakup = SubjectSplit.objects.filter(
-            name=paper_breakup).values_list(
+            name=paper_breakup.upper()).values_list(
                 'question_weightage',
                 'question_type',
                 'total_questions',


### PR DESCRIPTION
This PR removes the option to choose subject splits while generating test worksheets. The subject splits are chosen according to the board. For example, for board CBSE, all subject splits named "CBSE" will be chosen to decide the breakup  of marking scheme for the test paper.